### PR TITLE
Expand functionality of meta-orgconf

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,3 +9,4 @@
 #   DISTRO_FEATURES += " some_feature "
 
 BBPATH .= ":${LAYERDIR}"
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*.bbappend"

--- a/conf/org.conf
+++ b/conf/org.conf
@@ -1,0 +1,4 @@
+# Organizational-specific changes to influence how builds occur/sources
+# are fetched live here.
+
+NILRT_GIT ?= "git://github.com/ni"


### PR DESCRIPTION
Previously, meta-orgconf would not do anything other than allow the layer to be parsed (and, worse, nothing really pulled in other than bang-stock layer-type configs). Create the org.conf file to define the git repo to pull NI changes from and modify the layer.conf to consider additional recipes that can be populated in this layer.

[note: this change still depends on a change in nilrt to consider org.conf since the local.conf lives in that topmost repo. I will push that change once this is pulled]