### PR TITLE
Introduce 2018 orgconf branch, add URI variable

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,3 +9,4 @@
 #   DISTRO_FEATURES += " some_feature "
 
 BBPATH .= ":${LAYERDIR}"
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*.bbappend"

--- a/conf/org.conf
+++ b/conf/org.conf
@@ -1,0 +1,4 @@
+# Organizational-specific changes to influence how builds occur/sources
+# are fetched live here.
+
+NILRT_GIT ?= "git://github.com/ni"

--- a/conf/org.conf
+++ b/conf/org.conf
@@ -2,3 +2,4 @@
 # are fetched live here.
 
 NILRT_GIT ?= "git://github.com/ni"
+NILRT_FEED_BASE ?= "http://download.ni.com/ni-linux-rt/feeds/2018"


### PR DESCRIPTION
This set of changes introduces a new variable used in image generation. Previous releases would create images that point to the 2014 feeds, however no one actually complained.

This should not be pulled into master, but instead a new branch created to match the naming this request is coming from.