### PR TITLE
org.conf: Add 2020.7 ni-main feed version

### DIFF
--- a/conf/org.conf
+++ b/conf/org.conf
@@ -13,6 +13,7 @@ NILRT_ADDITIONAL_FEED_URIS += "\
 
 # Use internal development feeds
 NILRT_FEEDS_URI ?= "http://nickdanger.amer.corp.natinst.com/feeds"
+NILRT_MAIN_FEED_VERSION ?= "2020.7"
 
 NILRT_GIT_RO_PROTO ?= "git://"
 NILRT_GIT_RW_PROTO ?= "https://"


### PR DESCRIPTION
For developing internally, use the 2020.7 ni-main feed from
nickdanger.

This variable is also set in a makefile when building in Azdo, but this change is needed when building outside of Azdo.
This variable is also set in [meta-nilrt](https://github.com/ni/meta-nilrt/blob/nilrt/master/dunfell/conf/distro/nilrt.inc#L121). Should I change it there instead?